### PR TITLE
Revert "Updates to Ubuntu, docker-engine, compose"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,13 @@ FROM ubuntu:16.04
 
 # install dependencies
 RUN apt-get update && \
-    apt-get -y upgrade && \
-    apt-get install -y apt-transport-https ca-certificates software-properties-common curl build-essential git curl libsystemd-dev && \
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    curl -fsSL https://github.com/docker/compose/releases/download/1.16.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
+    apt-get install -y apt-transport-https ca-certificates build-essential git curl libsystemd-dev && \
+    apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
+    echo "deb https://apt.dockerproject.org/repo ubuntu-wily main" > /etc/apt/sources.list.d/docker.list && \
+    curl -s -L https://github.com/docker/compose/releases/download/1.7.1/docker-compose-$(uname -s)-$(uname -m) > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose && \
     apt-get update && \
-    apt-get install -y docker-ce=17.06.0~ce-0~ubuntu && \
+    apt-get install -y docker-engine=1.9.1-0~wily && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
In `golang-private-image`, we've bumped `awscli` and added the `--no-include-email` flag, but we're still getting this for any build that's using docker-private-image:

```
==> $(aws ecr get-login --no-include-email --region us-west-2)
Warning: failed to get default registry endpoint from daemon (Error response from daemon: client is newer than server (client API version: 1.24, server API version: 1.21)). Using system default: https://index.docker.io/v1/
Error response from daemon: client is newer than server (client API version: 1.24, server API version: 1.21)
/usr/src/Makefile.golang-private:154: recipe for target 'ecr.login' failed
make: *** [ecr.login] Error 1
```

Hoping to revert this commit along with the changes to `golang-private-image` to support the new docker client.

cc @segmentio/gateway 